### PR TITLE
Remove Node.js 12 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,4 +15,4 @@ jobs:
   test:
     uses: stylelint/.github/.github/workflows/test.yml@main
     with:
-      node-version: '["12", "14", "16", "18"]'
+      node-version: '["14", "16", "18"]'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
 				"prettier": "^2.0.4"
 			},
 			"engines": {
-				"node": "^12",
-				"npm": "^6"
+				"node": ">=14",
+				"npm": ">=8"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
 		"prettier": "^2.0.4"
 	},
 	"engines": {
-		"node": "^12",
-		"npm": "^6"
+		"node": ">=14",
+		"npm": ">=8"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 12 is EOL.
