### PR TITLE
Remove Node.js less than 18.12.0 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '**'
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,32 @@
+# Changelog
+
+## Head
+
+- Removed: Node.js less than 18.12.0 support.
+
 ## 4.0.0
 
-- Remove Node.js 14 support.
-- Bump `npm-package-json-lint` to `^7.0.0`.
-- Bump `npm-package-json-lint-config-default` to `^6.0.0`.
+- Removed: Node.js 14 support.
+- Changed: bump `npm-package-json-lint` to `^7.0.0`.
+- Changed: bump `npm-package-json-lint-config-default` to `^6.0.0`.
 
 ## 3.0.0
 
-- Remove Node.js 12 support.
-- Remove redundant sorting rules for deps.
-- Bump `npm-package-json-lint` to `^6.4.0`.
-- Bump `npm-package-json-lint-config-default` to `^5.0.0`.
+- Removed: Node.js 12 support.
+- Removed: redundant sorting rules for deps.
+- Changed: bump `npm-package-json-lint` to `^6.4.0`.
+- Changed: bump `npm-package-json-lint-config-default` to `^5.0.0`.
 
 ## 2.0.0
 
-- Add `require-funding` rule.
-- Remove `require-bugs` and `require-homepage` rules.
-- Bump `npm-package-json-lint-config-default` to v3.0.0.
-- Bump `npm-package-json-lint` to v5.0.0.
+- Added: `require-funding` rule.
+- Removed: `require-bugs` and `require-homepage` rules.
+- Changed: bump `npm-package-json-lint-config-default` to v3.0.0.
+- Changed: bump `npm-package-json-lint` to v5.0.0.
 
 ## 1.1.0
 
-- Remove `prefer-property-order` to leverage Prettier automatic sorting.
+- Removed: `prefer-property-order` to leverage Prettier automatic sorting.
 
 ## 1.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "prettier": "^3.0.0"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=18.12.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,7 @@
     "prettier": "^3.0.0"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 18.12.0 started the LTS support.

In addition, this change makes the changelog format consistent with other repositories.
