### PR TITLE
Change `npm-package-json-lint` to a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Head
 
 - Removed: Node.js less than 18.12.0 support.
+- Changed: `npm-package-json-lint` to a peer dependency.
 
 ## 4.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "npm-package-json-lint": "^7.0.0",
         "npm-package-json-lint-config-default": "^6.0.0"
       },
       "devDependencies": {
@@ -20,6 +19,7 @@
         "jest": "^29.6.1",
         "lint-staged": "^13.2.3",
         "np": "^8.0.4",
+        "npm-package-json-lint": "^7.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.0"
       },
@@ -29,6 +29,9 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/stylelint"
+      },
+      "peerDependencies": {
+        "npm-package-json-lint": "^7.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8011,9 +8014,9 @@
       }
     },
     "node_modules/npm-package-json-lint": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-7.0.0.tgz",
-      "integrity": "sha512-Yn8flnPx/7hTxwejWL5urm8sbEahq8ic3R80d7nlBvS6C58JEmJpUqvO7Ksy8izRzpbrHq0Anwlv/nQg5OYf8Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-7.1.0.tgz",
+      "integrity": "sha512-ypcMpag32TCP89zzLSS+7vjeR2QY613WzmO2upcJgKNWlcswDz8cdb80urbBNHkhSPI40ex3nsKrRDH/WhMYOg==",
       "dependencies": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -8027,10 +8030,10 @@
         "log-symbols": "^4.1.0",
         "meow": "^9.0.0",
         "plur": "^4.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.5.4",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1",
-        "type-fest": "^3.12.0",
+        "type-fest": "^4.3.3",
         "validate-npm-package-name": "^5.0.0"
       },
       "bin": {
@@ -8394,11 +8397,11 @@
       }
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
+      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     ]
   },
   "dependencies": {
-    "npm-package-json-lint": "^7.0.0",
     "npm-package-json-lint-config-default": "^6.0.0"
   },
   "devDependencies": {
@@ -78,8 +77,12 @@
     "jest": "^29.6.1",
     "lint-staged": "^13.2.3",
     "np": "^8.0.4",
+    "npm-package-json-lint": "^7.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0"
+  },
+  "peerDependencies": {
+    "npm-package-json-lint": "^7.0.0"
   },
   "engines": {
     "node": ">=18.12.0"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The official guide recommends putting it in `peerDependencies`.

> Please also add a dependency on npm-package-json-lint using peerdependencies

https://npmpackagejsonlint.org/docs/configuration#how-to-publish-a-shared-config-module
