### PR TITLE
Exclude ESLint deps from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
-        exclude-patterns: ['npm-package-json-lint']
+        exclude-patterns: ['npm-package-json-lint', 'eslint', 'eslint-*']
       npm-package-json-lint:
         patterns: ['npm-package-json-lint']
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

To avoid such a CI failure like:
https://github.com/stylelint/npm-package-json-lint-config/actions/runs/9747072481/job/26898900067?pr=59