### PR TITLE
Fix missing GitHub Sponsor to `funding` field in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed: bump `npm-package-json-lint` to `^8.0.0`.
 - Changed: bump `npm-package-json-lint-config-default` to `^7.0.0`.
+- Fixed: missing GitHub Sponsor to `funding` field in `package.json`.
 
 ## 5.0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,16 @@
     "": {
       "name": "@stylelint/npm-package-json-lint-config",
       "version": "5.0.1",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "npm-package-json-lint-config-default": "^7.0.1"
@@ -24,10 +34,6 @@
       },
       "engines": {
         "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/stylelint"
       },
       "peerDependencies": {
         "npm-package-json-lint": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,16 @@
     "npm-package-json-lint-config"
   ],
   "repository": "stylelint/npm-package-json-lint-config",
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/stylelint"
-  },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/stylelint"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stylelint"
+    }
+  ],
   "license": "MIT",
   "author": "stylelint",
   "main": "lib/npm-package-json-lint-config.js",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/7707

> Is there anything in the PR that needs further explanation?

Ref https://github.com/sponsors/stylelint

To verify this change, run `npm fund` like this:

```sh-session
$ npm fund .
1: opencollective funding available at the following URL: https://opencollective.com/stylelint
2: github funding available at the following URL: https://github.com/sponsors/stylelint
Run `npm fund [<package-spec>] --which=1`, for example, to open the first funding URL listed in that package
```