### PR TITLE
Shorten dev dependencies group name for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     labels:
       - 'pr: dependencies'
     groups:
-      development-dependencies:
-        dependency-type: 'development'
+      dev-deps:
+        dependency-type: development
         exclude-patterns: ['npm-package-json-lint']
       npm-package-json-lint:
         patterns: ['npm-package-json-lint', 'npm-package-json-lint-*']


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The original name is too verbose.
