### PR TITLE
Remove Node.js less than `22.0.0` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Removed: Node.js less than `22.0.0` support.
+
 ## 5.1.0
 
 - Changed: bump `npm-package-json-lint` to `^8.0.0`.
@@ -12,7 +16,7 @@
 
 ## 5.0.0
 
-- Removed: Node.js less than 18.12.0 support.
+- Removed: Node.js less than `18.12.0` support.
 - Changed: `npm-package-json-lint` to a peer dependency.
 
 ## 4.0.0
@@ -32,8 +36,8 @@
 
 - Added: `require-funding` rule.
 - Removed: `require-bugs` and `require-homepage` rules.
-- Changed: bump `npm-package-json-lint-config-default` to v3.0.0.
-- Changed: bump `npm-package-json-lint` to v5.0.0.
+- Changed: bump `npm-package-json-lint` to `^5.0.0`.
+- Changed: bump `npm-package-json-lint-config-default` to `^3.0.0`.
 
 ## 1.1.0
 

--- a/lib/npm-package-json-lint-config.test.mjs
+++ b/lib/npm-package-json-lint-config.test.mjs
@@ -1,4 +1,4 @@
-import { describe, test } from 'node:test'; // eslint-disable-line n/no-unsupported-features/node-builtins
+import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import npmpackagejsonlintConfig from './npm-package-json-lint-config.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "prettier": "^3.8.3"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "npm-package-json-lint": "^10.4.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "npm-package-json-lint": "^10.4.0"
   },
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR aligns the Node.js requirement with `npm-package-json-lint` packages:

```sh-session
$ npm view npm-package-json-lint@10.4.0 engines.node
>=22.0.0

$ npm view npm-package-json-lint-config-default@9.0.1 engines.node
>=22.0.0
```

Also, this adds backticks around version numbers in `CHANGELOG.md` entries for consistency.

See also: https://nodejs.org/en/about/previous-releases